### PR TITLE
 Issue #11. Add validation messages

### DIFF
--- a/auth-service/src/main/java/com/coungard/controller/AuthController.java
+++ b/auth-service/src/main/java/com/coungard/controller/AuthController.java
@@ -10,6 +10,7 @@ import com.coungard.security.UserPrincipal;
 import com.coungard.service.AuthService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -33,14 +34,14 @@ public class AuthController {
 
   @ApiOperation(value = "Sing In user")
   @PostMapping("/login")
-  public ResponseEntity<DetailedAuthenticationResponse> login(@RequestBody LoginRequest loginRequest) {
+  public ResponseEntity<DetailedAuthenticationResponse> login(@RequestBody @Valid LoginRequest loginRequest) {
     return ResponseEntity.ok(authService.authenticateUser(loginRequest));
   }
 
   @ApiOperation(value = "Sign Up user")
   @PostMapping("/sign-up")
   @ResponseStatus(HttpStatus.CREATED)
-  public ResponseEntity<AuthenticationResponse> signUpUser(@RequestBody SignUpRequest signUpRequest) {
+  public ResponseEntity<AuthenticationResponse> signUpUser(@RequestBody @Valid SignUpRequest signUpRequest) {
     return ResponseEntity.ok(authService.registerUser(signUpRequest));
   }
 
@@ -48,7 +49,7 @@ public class AuthController {
   @PreAuthorize("hasRole('ADMIN')")
   @PostMapping("/create-courier")
   @ResponseStatus(HttpStatus.CREATED)
-  public ResponseEntity<AuthenticationResponse> createCourier(@RequestBody SignUpRequest signUpRequest) {
+  public ResponseEntity<AuthenticationResponse> createCourier(@RequestBody @Valid SignUpRequest signUpRequest) {
     return ResponseEntity.ok(authService.registerCourier(signUpRequest));
   }
 

--- a/order-service/src/main/java/com/coungard/exception/GlobalExceptionHandler.java
+++ b/order-service/src/main/java/com/coungard/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.coungard.exception;
 
-import com.coungard.model.ErrorResponse;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -9,30 +8,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
-
-  @ExceptionHandler(ConflictException.class)
-  @ResponseStatus(HttpStatus.CONFLICT)
-  public ErrorResponse conflictHandler(ConflictException exception) {
-    log.info(exception.getMessage());
-    return new ErrorResponse(HttpStatus.CONFLICT.value(), exception.getMessage());
-  }
-
-  @ExceptionHandler(ApplicationException.class)
-  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-  public ErrorResponse httpClientErrorHandler(HttpClientErrorException httpClientErrorException) {
-    log.info(httpClientErrorException.getMessage());
-    return new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), httpClientErrorException.getMessage());
-  }
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @Override


### PR DESCRIPTION
Now we have a human readable form of validation errors for all endpoints.

For example, what happend if we using incorrect data for /login query:
![изображение](https://user-images.githubusercontent.com/32792990/229949947-aa8db5b9-0986-4cdd-ad23-2bf854ca69d6.png)
